### PR TITLE
Fix `py_venv_library` not propagating runfiles.

### DIFF
--- a/python/venv/private/tests/external_deps/pytest/BUILD.bazel
+++ b/python/venv/private/tests/external_deps/pytest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//python/venv:defs.bzl", "py_venv_test")
+load("//python/venv:defs.bzl", "py_venv_library", "py_venv_test")
 
 py_venv_test(
     name = "pytest_test",
@@ -7,4 +7,21 @@ py_venv_test(
         "@pip_deps//:pytest",
         "@pip_deps//:pytest_cov",
     ],
+)
+
+py_venv_library(
+    name = "pytest_wrapper",
+    deps = [
+        "@pip_deps//:pytest",
+        "@pip_deps//:pytest_cov",
+    ],
+)
+
+# Demonstrate that package metadata can be found in transitive
+# library targets.
+py_venv_test(
+    name = "wrapped_pytest_test",
+    srcs = ["pytest_test.py"],
+    main = "pytest_test.py",
+    deps = [":pytest_wrapper"],
 )

--- a/python/venv/private/venv.bzl
+++ b/python/venv/private/venv.bzl
@@ -27,10 +27,14 @@ def _py_venv_library_impl(ctx):
         deps = ctx.attr.deps,
     )
 
+    runfiles = dep_info.runfiles.merge(
+        ctx.runfiles(files = ctx.files.srcs + ctx.files.data),
+    )
+
     return [
         DefaultInfo(
             files = depset(ctx.files.srcs),
-            runfiles = ctx.runfiles(files = ctx.files.srcs + ctx.files.data),
+            runfiles = runfiles,
         ),
         venv_common.create_py_info(
             ctx = ctx,


### PR DESCRIPTION
This fixes the ability to access transitive package metadata which leads to issues like the following:
```
importlib.metadata.PackageNotFoundError: No package metadata was found for isort
```