### PR TITLE
Fix warnings on windows during cleanup

### DIFF
--- a/python/venv/private/tests/zipapp/python_zip_file_consumer.bzl
+++ b/python/venv/private/tests/zipapp/python_zip_file_consumer.bzl
@@ -30,11 +30,11 @@ def _python_zip_file_consumer_impl(ctx):
     )]
 
 python_zip_file_consumer = rule(
-    doc = "A rule for invoking `python_zip_file` files from `py_venv_binary` targets.",
+    doc = "A rule for invoking the zipapp from `py_venv_zipapp` targets.",
     implementation = _python_zip_file_consumer_impl,
     attrs = {
         "zip_file": attr.label(
-            doc = "A zipapp extracted from `python_zip_file`.",
+            doc = "A `py_venv_zipapp` target.",
             mandatory = True,
             allow_single_file = True,
         ),

--- a/python/venv/private/venv_process_wrapper.py
+++ b/python/venv/private/venv_process_wrapper.py
@@ -222,6 +222,21 @@ def install_files(
             install_fn(abs_src, abs_dest)
 
 
+def rmtree(path: Path | str) -> None:
+    """Attempt to delete a directory tree."""
+    # Here we use `TemporaryDirectory` to wrap the path to delete and delete it.
+    # Internally this will spawn an additional temp directory inside of `path`
+    # but this should not matter as the parent directory will immediately be cleaned up.
+    # pylint: disable-next=consider-using-with
+    wrapper = tempfile.TemporaryDirectory(dir=path)
+
+    # Override the path represented by `TemporaryDirectory`
+    wrapper.name = str(path)
+
+    # Cleanup the parent directory.
+    wrapper.cleanup()
+
+
 def main() -> None:
     """The main entrypoint."""
     args = parse_args()
@@ -318,7 +333,7 @@ def main() -> None:
             logging.debug("Skipping cleanup of: %s", temp_dir)
         else:
             try:
-                shutil.rmtree(temp_dir)
+                rmtree(temp_dir)
             except (PermissionError, OSError) as exc:
                 logging.warning(
                     "Error encountered while cleaning up venv %s: %s", temp_dir, exc


### PR DESCRIPTION
On windows `py_venv_binary` would generally always print a warning at the end of any execution
```
WARNING:root:Error encountered while cleaning up venv D:\a\_temp\venv-consumer_unit_test.mypy-axyhwpi0: [WinError 5] Access is denied: 'D:\\a\\_temp\\venv-consumer_unit_test.mypy-axyhwpi0\\runfiles\\_main\\python\\mypy\\private\\tests\\simple\\consumer_unit_test.bat'
```
While I don't fully understand the issue, it appears either python is making some files read-only or it causes something on the system to keep files open despite the process exiting. To account for this, `tempfile.TemporaryDirectory` is used to wrap the directory to delete and then delete it using it's more robust functionality.